### PR TITLE
[NSA-6262] add serviceNowUrl to hostingEnvironment schema

### DIFF
--- a/lib/hostingEnvironment.js
+++ b/lib/hostingEnvironment.js
@@ -91,6 +91,11 @@ module.exports = new SimpleSchema({
     regEx: patterns.url,
     optional: true,
   },
+  serviceNowUrl: {
+    type: String,
+    regEx: patterns.url,
+    optional: true,
+  },
   redisPingInSeconds: {
     type: SimpleSchema.Integer,
     optional: true,


### PR DESCRIPTION
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-6262

Why?
A url to redirect user to service-now contact form is required in Manage console.
Already added to the config files.